### PR TITLE
:memo: Adding upgrade policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,11 @@ For additional information and documentation on FusionAuth refer to [https://fus
 This library is currently in development it is not yet available for public consumption.
 
 > **WARNING**: This project is still in development, feel free to use, but it may not work. You may still feel free to open issues or submit PRs. 
+
+## Upgrade Policy
+
+This library is built automatically to keep track of the FusionAuth API, and may also receive updates with bug fixes, security patches, tests, code samples, or documentation changes.
+
+These releases may also update dependencies, language engines, and operating systems, as we\'ll follow the deprecation and sunsetting policies of the underlying technologies that it uses.
+
+This means that after a dependency (e.g. language, framework, or operating system) is deprecated by its maintainer, this library will also be deprecated by us, and will eventually be updated to use a newer version.


### PR DESCRIPTION
Adding the "Upgrade Policy" section as [described here](https://github.com/FusionAuth/fusionauth-site/pull/2916).